### PR TITLE
fix: preserve UTF-8 editor text

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 group = "com.specops"
 
-version = "1.4.1"
+version = "1.4.2"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/specops/ui/MainTab.java
+++ b/src/main/java/com/specops/ui/MainTab.java
@@ -38,7 +38,7 @@ public class MainTab extends JPanel {
         tabbedPane.addTab("5. Custom Headers", customHeadersTab);
         tabbedPane.addTab("6. Endpoints Workbench", endpointsTab);
         tabbedPane.addTab("7. Attack Results", resultsTab);
-        tabbedPane.addTab("About", new AboutMeTab("SpecOps", "1.4.1"));
+        tabbedPane.addTab("About", new AboutMeTab("SpecOps", "1.4.2"));
 
 
         add(tabbedPane, BorderLayout.CENTER);

--- a/src/main/java/com/specops/ui/SpecificationTab.java
+++ b/src/main/java/com/specops/ui/SpecificationTab.java
@@ -191,7 +191,7 @@ public class SpecificationTab extends JPanel {
     }
 
     private void parseSpecification() {
-        String specContent = specArea.getContents().toString();
+        String specContent = new String(specArea.getContents().getBytes(), StandardCharsets.UTF_8);
         if (specContent.trim().isEmpty()) {
             JOptionPane.showMessageDialog(this, "Specification content is empty.", "Error", JOptionPane.ERROR_MESSAGE);
             return;


### PR DESCRIPTION
Decode RawEditor bytes as UTF-8 and bump v1.4.2.